### PR TITLE
	modified:   src/main.rs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use std::{env, fs, process::Command};
 use colored::*;
 
 fn get_version(crate_name: &str) -> Result<String, String> {
-    if let Ok(resp) = Command::new("cargo").arg("search").arg(crate_name).output() {
+    if let Ok(resp) = Command::new("cargo").arg("search").arg("--registry").arg("crates-io").arg(crate_name).output() {
         let resp_string = String::from_utf8_lossy(&resp.stdout)
             .to_owned()
             .split("\n...")


### PR DESCRIPTION
When ~/.cargo/config is not blank, e.g., 
```
[source.crates-io]
registry = "https://github.com/rust-lang/crates.io-index"
replace-with = 'tuna'
[source.ustc]
registry = "git://mirrors.ustc.edu.cn/crates.io-index"

[source.tuna]
registry = "https://mirrors.tuna.tsinghua.edu.cn/git/crates.io-index.git"
```

`cargo stabilize --upgrade` does not work.
The reason is that `cargo search`  requires an extra argument `--registry crates-io` in this condition.
