### PR TITLE
Add option specific to enforce concrete versions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,16 +38,19 @@ Usage:
 
 Flags:
     -h | --help     Display usage information
+    --specific      Set specific version with prefix '='
     --upgrade       Upgrade all dependency versions to the newest,
                     not just wilcards
 ";
 
 fn main() {
     // Read command-line arguments
+    let mut specific = false;
     let mut upgrade = false;
     for arg in env::args().skip_while(|s| s != "stabilize").skip(1) {
         match arg.as_ref() {
             "-h" | "--help" => println!("{}", USAGE_STRING),
+            "--specific" => specific = true,
             "--upgrade" => upgrade = true,
             _ => println!("Unknown command\n{}", USAGE_STRING),
         }
@@ -101,7 +104,11 @@ fn main() {
                                                     } else if upgrade {
                                                         upgraded += 1;
                                                     }
-                                                    *version = ver;
+                                                    *version = if specific {
+                                                        String::from("=") + &ver
+                                                    } else {
+                                                        ver
+                                                    };
                                                 }
                                             }
                                             Err(e) => println!("{}", e),


### PR DESCRIPTION
First of all thank you for this tool. Exactly what I am looking for.

This PR adds an option to enforce a concrete version (`"=1.0.0"`) rather than a range (`"1.0.0"`). [[doc](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-cratesio)]